### PR TITLE
Add missing re dependency to opam file

### DIFF
--- a/ReasonNativeProject.opam
+++ b/ReasonNativeProject.opam
@@ -18,5 +18,6 @@ build: [
 depends: [
   "jbuilder" {build}
   "reason"  {= "2.0.0"}
+  "re"
 ]
 available: [ ocaml-version >= "4.02" & ocaml-version < "4.05" ]


### PR DESCRIPTION
This PR adds a missing `re` dependency to `ReasonNativeProject.opam`

**Context:**

I followed the steps in the README and it did not work out of the box. I got an error
related to a missing `re` dependency after running:

```sh
opam pin add -y ReasonNativeProject .
```

```sh
=-=- Processing actions -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  🐫
[ERROR] The compilation of ReasonNativeProject failed at "jbuilder build -p ReasonNativeProject -j 4".

#=== ERROR while installing ReasonNativeProject.0.0.1 =========================#
# opam-version 1.2.2
# os           darwin
# command      jbuilder build -p ReasonNativeProject -j 4
# path         /Users/arielschiavoni/.opam/4.02.3/build/ReasonNativeProject.0.0.1
# compiler     4.02.3
# exit-code    1
# env-file     /Users/arielschiavoni/.opam/4.02.3/build/ReasonNativeProject.0.0.1/ReasonNativeProject-26999-ffb3fd.env
# stdout-file  /Users/arielschiavoni/.opam/4.02.3/build/ReasonNativeProject.0.0.1/ReasonNativeProject-26999-ffb3fd.out
# stderr-file  /Users/arielschiavoni/.opam/4.02.3/build/ReasonNativeProject.0.0.1/ReasonNativeProject-26999-ffb3fd.err
### stderr ###
# Error: External library "re" not found.
# -> required by "lib/jbuild (context default)"
# Hint: try: jbuilder external-lib-deps --missing -p ReasonNativeProject @install
```
